### PR TITLE
Basic support for rails 4.1

### DIFF
--- a/lib/forceps/client.rb
+++ b/lib/forceps/client.rb
@@ -146,11 +146,7 @@ module Forceps
       cloned_association = association.dup
       cloned_association.instance_variable_set("@klass", related_remote_class)
 
-      cloned_reflections = remote_model_class.reflections.dup
-      cloned_reflections[cloned_association.name.to_sym] = cloned_association
-      remote_model_class.reflections = cloned_reflections
+      ActiveRecord::Reflection.add_reflection(remote_model_class, cloned_association.name, cloned_association)
     end
   end
 end
-
-

--- a/lib/forceps/client.rb
+++ b/lib/forceps/client.rb
@@ -65,7 +65,7 @@ module Forceps
 
         include Forceps::ActsAsCopyableModel
 
-        # Intercep intantiation of records to make the 'type' column point to the corresponding remote class
+        # Intercept instantiation of records to make the 'type' column point to the corresponding remote class
         if Rails::VERSION::MAJOR >= 4
           def self.instantiate(record, column_types = {})
             __make_sti_column_point_to_forceps_remote_class(record)
@@ -118,13 +118,13 @@ module Forceps
       remote_model_class = remote_class_for(model_class.name)
 
       if association.options[:polymorphic]
-        reference_remote_class_in_polymorfic_association(association, remote_model_class)
+        reference_remote_class_in_polymorphic_association(association, remote_model_class)
       else
         reference_remote_class_in_normal_association(association, remote_model_class)
       end
     end
 
-    def reference_remote_class_in_polymorfic_association(association, remote_model_class)
+    def reference_remote_class_in_polymorphic_association(association, remote_model_class)
       foreign_type_attribute_name = association.foreign_type
 
       remote_model_class.send(:define_method, association.foreign_type) do
@@ -132,7 +132,7 @@ module Forceps
       end
 
       remote_model_class.send(:define_method, "[]") do |attribute_name|
-        if (attribute_name.to_s==foreign_type_attribute_name)
+        if (attribute_name.to_s == foreign_type_attribute_name)
           "Forceps::Remote::#{super(attribute_name)}"
         else
           super(attribute_name)

--- a/lib/forceps/client.rb
+++ b/lib/forceps/client.rb
@@ -22,7 +22,13 @@ module Forceps
     end
 
     def model_classes
-      @model_classes ||= ActiveRecord::Base.descendants - model_classes_to_exclude
+      @model_classes ||= filtered_model_classes
+    end
+
+    def filtered_model_classes
+      (ActiveRecord::Base.descendants - model_classes_to_exclude).reject do |klass|
+        klass.name.start_with?('HABTM_')
+      end
     end
 
     def model_classes_to_exclude

--- a/test/callbacks_test.rb
+++ b/test/callbacks_test.rb
@@ -7,9 +7,9 @@ class CallbacksTest < ActiveSupport::TestCase
 
   test "should invoke the configured 'after_each' callback" do
     after_each_callback_mock = MiniTest::Mock.new
-    after_each_callback_mock.expect(:call, nil) do |args|
-      assert_equal Product.find_by_name('MBP'), args[0]
-      assert_identical @remote_product, args[1]
+    after_each_callback_mock.expect(:call, nil) do |local, remote|
+      assert_equal Product.find_by_name('MBP'), local
+      assert_identical @remote_product, remote
     end
 
     Forceps.configure :after_each => {Product => after_each_callback_mock}

--- a/test/support/remote_address.rb
+++ b/test/support/remote_address.rb
@@ -1,7 +1,5 @@
 class RemoteAddress < Address
-  establish_connection 'remote'
+  establish_connection :remote
 
   belongs_to :user, class_name: 'RemoteUser'
 end
-
-

--- a/test/support/remote_invoice.rb
+++ b/test/support/remote_invoice.rb
@@ -1,8 +1,6 @@
 class RemoteInvoice < Invoice
-  establish_connection 'remote'
+  establish_connection :remote
 
   belongs_to :user, class_name: 'RemoteUser'
   has_many :line_items, class_name: 'RemoteLineItem'
 end
-
-

--- a/test/support/remote_line_item.rb
+++ b/test/support/remote_line_item.rb
@@ -1,8 +1,6 @@
 class RemoteLineItem < LineItem
-  establish_connection 'remote'
+  establish_connection :remote
 
   belongs_to :product, class_name: 'RemoteProduct'
   belongs_to :invoice, class_name: 'RemoteInvoice', foreign_key: 'invoice_id'
 end
-
-

--- a/test/support/remote_product.rb
+++ b/test/support/remote_product.rb
@@ -1,8 +1,6 @@
 class RemoteProduct < Product
-  establish_connection 'remote'
+  establish_connection :remote
 
   has_many :line_items, class_name: 'RemoteLineItem', foreign_key: 'product_id'
   has_and_belongs_to_many :tags, class_name: 'RemoteTag', join_table: 'products_tags', foreign_key: 'product_id', association_foreign_key: 'tag_id'
 end
-
-

--- a/test/support/remote_tag.rb
+++ b/test/support/remote_tag.rb
@@ -1,7 +1,5 @@
 class RemoteTag < Tag
-  establish_connection 'remote'
+  establish_connection :remote
 
   has_and_belongs_to_many :products, class_name: 'RemoteProduct', join_table: 'products_tags', foreign_key: 'tag_id', association_foreign_key: 'product_id'
 end
-
-

--- a/test/support/remote_user.rb
+++ b/test/support/remote_user.rb
@@ -1,8 +1,6 @@
 class RemoteUser < User
-  establish_connection 'remote'
+  establish_connection :remote
 
   has_one :address, class_name: 'RemoteAddress', foreign_key: 'user_id'
   has_many :invoices, class_name: 'RemoteInvoice', foreign_key: 'user_id'
 end
-
-


### PR DESCRIPTION
This is a few fixes to get forceps to mostly work with rails 4.1. I don't think its backwards compatible though.

I wasn't able to get has_and_belongs_to_many associations to work because they have completely changed in 4.1. They are now modeled as a has_many to a generated class. I'm excluding that generated class, so if you don't use that relationship, then forceps will work.