### PR TITLE
Change dir back to root before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
   - RAILS_ENV=test rake db:create db:migrate
   - RAILS_ENV=remote rake db:create db:migrate
 script:
+  - cd ${TRAVIS_BUILD_DIR}
   - rake test
 
 


### PR DESCRIPTION
This change makes Travis actually run the test, which didn't happen before.

This reveals that the tests fail on all combination of Ruby and Rails versions.