### PR TITLE
Fix the blacklist check for polymorphic models

### DIFF
--- a/lib/forceps/acts_as_copyable_model.rb
+++ b/lib/forceps/acts_as_copyable_model.rb
@@ -232,6 +232,7 @@ module Forceps
             excluded_attributes.include?(:all_associations) ||
             excluded_attributes.include?(association.name) ||
             options.fetch(:ignore_model, []).include?(to_local_class_name(association.klass.name))
+            (!association.options[:polymorphic] && options.fetch(:ignore_model, []).include?(to_local_class_name(association.klass.name)))
         end
       end
 

--- a/lib/forceps/acts_as_copyable_model.rb
+++ b/lib/forceps/acts_as_copyable_model.rb
@@ -231,7 +231,6 @@ module Forceps
           association.options[:through] ||
             excluded_attributes.include?(:all_associations) ||
             excluded_attributes.include?(association.name) ||
-            options.fetch(:ignore_model, []).include?(to_local_class_name(association.klass.name))
             (!association.options[:polymorphic] && options.fetch(:ignore_model, []).include?(to_local_class_name(association.klass.name)))
         end
       end


### PR DESCRIPTION
I wanted to fix my bug, hopefully before anyone noticed.

in polymorphic associations klass is not set, so we need to bail out before we check the class name
This means it is likely not possible or easy to blacklist a polymorphic association by model name.

I think I am ok with this limitation for now.